### PR TITLE
DBのスキーマモデル修正

### DIFF
--- a/dao/weather.go
+++ b/dao/weather.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Weather struct {
-	Location    string `gorm:"size:255"`
+	Location    string `gorm:"type:varchar(100)"`
 	Weather     string `gorm:"type:varchar(100)"`
 	Temperature float64
 	Clouds      uint32


### PR DESCRIPTION
固定長だと不要な空白ができてしまうため、可変長に変更